### PR TITLE
Make APIs Kotlin friendly

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The [sample project](https://github.com/saket/Flick/tree/master/sample/src/main/
 Flick requires you to manually provide the content dimensions instead of it checking the content's height. This is useful for scalable `ImageViews`, where the height will always be set to match-parent, but the actual image may not be consuming the entire height.
 
 ```kotlin
-val contentHeightProvider = object : ContentHeightProvider {
+val contentSizeProvider = object : ContentSizeProvider {
   override val heightForDismissAnimation: Int
     get() = imageView.drawable * imageView.zoomRatio
 
@@ -36,7 +36,7 @@ val contentHeightProvider = object : ContentHeightProvider {
     }
 }
 
-val callbacks = object : GestureCallbacks {
+val callbacks = object : FlickCallbacks {
   override fun onFlickDismiss(animationDuration: Long) {
     // Called when the View has been flicked and the Activity
     // should be dismissed.
@@ -49,6 +49,7 @@ val callbacks = object : GestureCallbacks {
   }
 }
 
+val flickDismissLayout: FlickDismissLayout = findViewById(...)
 flickDismissLayout.gestureListener = FlickGestureListener(context, contentSizeProvider, callbacks)
 ```
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Flick is a tiny library for flick dismissing images (or anything actually). You 
 
 ## Usage
 
-The [sample project](https://github.com/saket/Flick/tree/master/sample/src/main/java/me/saket/flick/sample) contains best practices for using Flick. You can also [download an APK from here](https://github.com/saket/Flick/releases) for testing it on your phone.
+The [sample project](https://github.com/saket/Flick/tree/master/sample/src/main/java/me/saket/flick/sample) contains best practices for using Flick. You can [download the APK from here](https://github.com/saket/Flick/releases) for testing it on your phone.
 
 ```xml
 <me.saket.flick.FlickDismissLayout
@@ -59,7 +59,7 @@ In usecases where the content can be scrolled further in the direction of the ge
 
 ```kotlin
 // Block flick gestures if the image can pan further.
-gestureListener.onGestureInterceptor = { scrollY ->
+gestureListener.gestureInterceptor = { scrollY ->
   val isScrollingUpwards = scrollY < 0
   val directionInt = if (isScrollingUpwards) -1 else +1
   val canPanFurther = imageView.canScrollVertically(directionInt)

--- a/README.md
+++ b/README.md
@@ -53,6 +53,24 @@ val flickDismissLayout: FlickDismissLayout = findViewById(...)
 flickDismissLayout.gestureListener = FlickGestureListener(context, contentSizeProvider, callbacks)
 ```
 
+**Intercepting flicks**
+
+In usecases where the content can be scrolled further in the direction of the gesture, Flick also exposes a way for intercepting flick detection,
+
+```kotlin
+// Block flick gestures if the image can pan further.
+gestureListener.onGestureInterceptor = { scrollY ->
+  val isScrollingUpwards = scrollY < 0
+  val directionInt = if (isScrollingUpwards) -1 else +1
+  val canPanFurther = imageView.canScrollVertically(directionInt)
+
+  when {
+    canPanFurther -> InterceptResult.INTERCEPTED
+    else -> InterceptResult.IGNORED
+  }
+}
+```
+
 ## License
 
 ```

--- a/README.md
+++ b/README.md
@@ -25,15 +25,15 @@ Flick requires you to manually provide the content dimensions instead of it chec
 
 ```kotlin
 val contentSizeProvider = object : ContentSizeProvider {
-  override val heightForDismissAnimation: Int
-    get() = imageView.drawable * imageView.zoomRatio
+  override fun heightForDismissAnimation(): Int {
+    return imageView.zoomedImageHeight.toInt()
+  }
 
-  override val heightForCalculatingDismissThreshold: Int
-    get() {
-      // Zoomed in height minus the portions of image that has gone
-      // outside display bounds, because they are longer visible.
-      imageView.visibleZoomedImageHeight
-    }
+  override fun heightForCalculatingDismissThreshold(): Int {
+    // Zoomed in height minus the portions of image that has gone
+    // outside display bounds, because they are longer visible.
+    imageView.visibleZoomedImageHeight
+  }
 }
 
 val callbacks = object : FlickCallbacks {

--- a/README.md
+++ b/README.md
@@ -24,25 +24,19 @@ The [sample project](https://github.com/saket/Flick/tree/master/sample/src/main/
 Flick requires you to manually provide the content dimensions instead of it checking the content's height. This is useful for scalable `ImageViews`, where the height will always be set to match-parent, but the actual image may not be consuming the entire height.
 
 ```kotlin
-flickDismissLayout.gestureListener = FlickGestureListener(context).apply {
-  contentHeightProvider = object : ContentHeightProvider {
-    override val heightForDismissAnimation: Int
-      get() = imageView.drawable * imageView.zoomRatio
+val contentHeightProvider = object : ContentHeightProvider {
+  override val heightForDismissAnimation: Int
+    get() = imageView.drawable * imageView.zoomRatio
 
-    override val heightForCalculatingDismissThreshold: Int
-      get() {
-        // Zoomed in height minus the portions of image that has gone
-        // outside display bounds, because they are longer visible.
-        imageView.visibleZoomedImageHeight
-      }
+  override val heightForCalculatingDismissThreshold: Int
+    get() {
+      // Zoomed in height minus the portions of image that has gone
+      // outside display bounds, because they are longer visible.
+      imageView.visibleZoomedImageHeight
     }
 }
-```
 
-Flick offers two callbacks for receiving updates of gestures.
-
-```kotlin
-gestureListener.gestureCallbacks = object : GestureCallbacks {
+val callbacks = object : GestureCallbacks {
   override fun onFlickDismiss(animationDuration: Long) {
     // Called when the View has been flicked and the Activity
     // should be dismissed.
@@ -54,6 +48,8 @@ gestureListener.gestureCallbacks = object : GestureCallbacks {
     // background dimming is a good usecase for this callback.
   }
 }
+
+flickDismissLayout.gestureListener = FlickGestureListener(context, contentSizeProvider, callbacks)
 ```
 
 ## License

--- a/flick/src/main/java/me/saket/flick/ContentSizeProvider.kt
+++ b/flick/src/main/java/me/saket/flick/ContentSizeProvider.kt
@@ -6,10 +6,10 @@ interface ContentSizeProvider {
    * Height of the content with its scale taken into account. This is used for
    * animating the content out of the window when a flick is registered.
    */
-  val heightForDismissAnimation: Int
+  fun heightForDismissAnimation(): Int
 
   /**
    * Used for calculating if the content can be dismissed on finger up.
    */
-  val heightForCalculatingDismissThreshold: Int
+  fun heightForCalculatingDismissThreshold(): Int
 }

--- a/flick/src/main/java/me/saket/flick/ContentSizeProvider.kt
+++ b/flick/src/main/java/me/saket/flick/ContentSizeProvider.kt
@@ -1,6 +1,6 @@
 package me.saket.flick
 
-interface ContentHeightProvider {
+interface ContentSizeProvider {
 
   /**
    * Height of the content with its scale taken into account. This is used for

--- a/flick/src/main/java/me/saket/flick/FlickCallbacks.kt
+++ b/flick/src/main/java/me/saket/flick/FlickCallbacks.kt
@@ -2,7 +2,7 @@ package me.saket.flick
 
 import android.support.annotation.FloatRange
 
-interface GestureCallbacks {
+interface FlickCallbacks {
 
   /**
    * Called when the View has been flicked and the Activity should be dismissed.

--- a/flick/src/main/java/me/saket/flick/FlickGestureListener.kt
+++ b/flick/src/main/java/me/saket/flick/FlickGestureListener.kt
@@ -38,7 +38,7 @@ class FlickGestureListener(
    * [scrollY]: Distance moved since touch-down. Small, but sufficient for
    * checking the direction of scroll.
    */
-  var onGestureInterceptor: (scrollY: Float) -> InterceptResult = { InterceptResult.IGNORED }
+  var gestureInterceptor: (scrollY: Float) -> InterceptResult = { InterceptResult.IGNORED }
 
   private var downX = 0F
   private var downY = 0F
@@ -125,7 +125,7 @@ class FlickGestureListener(
         }
 
         // The listener only gets once chance to block the flick -- only if it's not already being moved.
-        if (verticalScrollRegistered.not() && onGestureInterceptor(distanceY) == INTERCEPTED) {
+        if (verticalScrollRegistered.not() && gestureInterceptor(distanceY) == INTERCEPTED) {
           gestureInterceptedUntilNextTouchDown = true
           return false
         }

--- a/flick/src/main/java/me/saket/flick/FlickGestureListener.kt
+++ b/flick/src/main/java/me/saket/flick/FlickGestureListener.kt
@@ -8,6 +8,7 @@ import android.view.MotionEvent
 import android.view.VelocityTracker
 import android.view.View
 import android.view.ViewConfiguration
+import me.saket.flick.InterceptResult.INTERCEPTED
 
 class FlickGestureListener(
     context: Context,
@@ -30,7 +31,14 @@ class FlickGestureListener(
   /** Px per second. */
   private val maximumFlingVelocity: Int = viewConfiguration.scaledMaximumFlingVelocity
 
-  var onGestureInterceptor: OnGestureInterceptor = OnGestureInterceptor.Default()
+  /**
+   * Called once every-time a scroll gesture is registered. When intercepted, gesture
+   * detection is skipped until the next touch-down.
+   *
+   * [scrollY]: Distance moved since touch-down. Small, but sufficient for
+   * checking the direction of scroll.
+   */
+  var onGestureInterceptor: (scrollY: Float) -> InterceptResult = { InterceptResult.IGNORED }
 
   private var downX = 0F
   private var downY = 0F
@@ -117,7 +125,7 @@ class FlickGestureListener(
         }
 
         // The listener only gets once chance to block the flick -- only if it's not already being moved.
-        if (verticalScrollRegistered.not() && onGestureInterceptor.shouldIntercept(deltaY)) {
+        if (verticalScrollRegistered.not() && onGestureInterceptor(distanceY) == INTERCEPTED) {
           gestureInterceptedUntilNextTouchDown = true
           return false
         }

--- a/flick/src/main/java/me/saket/flick/FlickGestureListener.kt
+++ b/flick/src/main/java/me/saket/flick/FlickGestureListener.kt
@@ -11,7 +11,7 @@ import android.view.ViewConfiguration
 
 class FlickGestureListener(
     context: Context,
-    private val contentHeightProvider: ContentHeightProvider,
+    private val contentHeightProvider: ContentSizeProvider,
     private val gestureCallbacks: GestureCallbacks
 ) : View.OnTouchListener {
 

--- a/flick/src/main/java/me/saket/flick/FlickGestureListener.kt
+++ b/flick/src/main/java/me/saket/flick/FlickGestureListener.kt
@@ -198,7 +198,7 @@ class FlickGestureListener(
     // I no longer remember the reason behind applying so many Math functions. Help.
     val rotationAngle = view.rotation
     val distanceRotated = Math.ceil(Math.abs(Math.sin(Math.toRadians(rotationAngle.toDouble())) * view.width / 2)).toInt()
-    val throwDistance = distanceRotated + Math.max(contentHeightProvider.heightForDismissAnimation, view.rootView.height)
+    val throwDistance = distanceRotated + Math.max(contentHeightProvider.heightForDismissAnimation(), view.rootView.height)
 
     view.animate().cancel()
     view.animate()
@@ -211,7 +211,7 @@ class FlickGestureListener(
   }
 
   private fun hasFingerMovedEnoughToFlick(distanceYAbs: Float): Boolean {
-    val thresholdDistanceY = contentHeightProvider.heightForCalculatingDismissThreshold * flickThresholdSlop
+    val thresholdDistanceY = contentHeightProvider.heightForCalculatingDismissThreshold() * flickThresholdSlop
     return distanceYAbs > thresholdDistanceY
   }
 

--- a/flick/src/main/java/me/saket/flick/FlickGestureListener.kt
+++ b/flick/src/main/java/me/saket/flick/FlickGestureListener.kt
@@ -12,7 +12,7 @@ import android.view.ViewConfiguration
 class FlickGestureListener(
     context: Context,
     private val contentHeightProvider: ContentSizeProvider,
-    private val gestureCallbacks: GestureCallbacks
+    private val flickCallbacks: FlickCallbacks
 ) : View.OnTouchListener {
 
   private val viewConfiguration: ViewConfiguration = ViewConfiguration.get(context)
@@ -163,7 +163,7 @@ class FlickGestureListener(
 
   private fun dispatchOnPhotoMoveCallback(view: View) {
     val moveRatio = view.translationY / view.height
-    gestureCallbacks.onMove(moveRatio)
+    flickCallbacks.onMove(moveRatio)
   }
 
   private fun animateViewBackToPosition(view: View) {
@@ -195,7 +195,7 @@ class FlickGestureListener(
     view.animate().cancel()
     view.animate()
         .translationY((if (downwards) throwDistance else -throwDistance).toFloat())
-        .withStartAction { gestureCallbacks.onFlickDismiss(flickAnimDuration) }
+        .withStartAction { flickCallbacks.onFlickDismiss(flickAnimDuration) }
         .setDuration(flickAnimDuration)
         .setInterpolator(ANIM_INTERPOLATOR)
         .setUpdateListener { dispatchOnPhotoMoveCallback(view) }

--- a/flick/src/main/java/me/saket/flick/OnGestureInterceptor.kt
+++ b/flick/src/main/java/me/saket/flick/OnGestureInterceptor.kt
@@ -1,19 +1,6 @@
 package me.saket.flick
 
-interface OnGestureInterceptor {
-
-  /**
-   * Called once every-time a scroll gesture is registered. When this returns
-   * true, gesture detection is skipped until the next touch-down.
-   *
-   * @return True to intercept the gesture, false otherwise to let it go.
-   */
-  fun shouldIntercept(deltaY: Float): Boolean
-
-  class Default : OnGestureInterceptor {
-    // Default gesture interceptor: don't intercept anything.
-    override fun shouldIntercept(deltaY: Float): Boolean {
-      return false
-    }
-  }
+enum class InterceptResult {
+  INTERCEPTED,
+  IGNORED
 }

--- a/sample/src/main/java/me/saket/flick/sample/viewer/ImageViewerActivity.kt
+++ b/sample/src/main/java/me/saket/flick/sample/viewer/ImageViewerActivity.kt
@@ -18,7 +18,7 @@ import me.saket.flick.ContentSizeProvider
 import me.saket.flick.FlickCallbacks
 import me.saket.flick.FlickDismissLayout
 import me.saket.flick.FlickGestureListener
-import me.saket.flick.OnGestureInterceptor
+import me.saket.flick.InterceptResult
 import me.saket.flick.sample.R
 import me.saket.flick.sample.UnsplashPhoto
 import me.saket.flick.sample.viewer.immersive.SystemUiHelper
@@ -122,14 +122,19 @@ class ImageViewerActivity : AppCompatActivity() {
     }
 
     val gestureListener = FlickGestureListener(this, contentHeightProvider, callbacks)
-    gestureListener.onGestureInterceptor = object : OnGestureInterceptor {
-      override fun shouldIntercept(deltaY: Float): Boolean {
-        // Don't listen for flick gestures if the image can pan further.
-        val isScrollingUpwards = deltaY < 0
-        val directionInt = if (isScrollingUpwards) -1 else +1
-        return imageView.canScrollVertically(directionInt)
+
+    // Block flick gestures if the image can pan further.
+    gestureListener.onGestureInterceptor = { scrollY ->
+      val isScrollingUpwards = scrollY < 0
+      val directionInt = if (isScrollingUpwards) -1 else +1
+      val canPanFurther = imageView.canScrollVertically(directionInt)
+
+      when {
+        canPanFurther -> InterceptResult.INTERCEPTED
+        else -> InterceptResult.IGNORED
       }
     }
+
     return gestureListener
   }
 

--- a/sample/src/main/java/me/saket/flick/sample/viewer/ImageViewerActivity.kt
+++ b/sample/src/main/java/me/saket/flick/sample/viewer/ImageViewerActivity.kt
@@ -99,16 +99,18 @@ class ImageViewerActivity : AppCompatActivity() {
 
   private fun flickGestureListener(): FlickGestureListener {
     val contentHeightProvider = object : ContentSizeProvider {
-      override val heightForDismissAnimation: Int
-        get() = imageView.zoomedImageHeight.toInt()
+      override fun heightForDismissAnimation(): Int {
+        return imageView.zoomedImageHeight.toInt()
+      }
 
       // A positive height value is important so that the user
       // can dismiss even while the progress indicator is visible.
-      override val heightForCalculatingDismissThreshold: Int
-        get() = when {
+      override fun heightForCalculatingDismissThreshold(): Int {
+        return when {
           imageView.drawable == null -> resources.getDimensionPixelSize(R.dimen.mediaalbumviewer_image_height_when_empty)
           else -> imageView.visibleZoomedImageHeight.toInt()
         }
+      }
     }
 
     val callbacks = object : FlickCallbacks {

--- a/sample/src/main/java/me/saket/flick/sample/viewer/ImageViewerActivity.kt
+++ b/sample/src/main/java/me/saket/flick/sample/viewer/ImageViewerActivity.kt
@@ -15,9 +15,9 @@ import android.view.WindowManager
 import com.squareup.picasso.Picasso
 import kotterknife.bindView
 import me.saket.flick.ContentSizeProvider
+import me.saket.flick.FlickCallbacks
 import me.saket.flick.FlickDismissLayout
 import me.saket.flick.FlickGestureListener
-import me.saket.flick.GestureCallbacks
 import me.saket.flick.OnGestureInterceptor
 import me.saket.flick.sample.R
 import me.saket.flick.sample.UnsplashPhoto
@@ -111,7 +111,7 @@ class ImageViewerActivity : AppCompatActivity() {
         }
     }
 
-    val gestureCallbacks = object : GestureCallbacks {
+    val callbacks = object : FlickCallbacks {
       override fun onFlickDismiss(flickAnimationDuration: Long) {
         finishInMillis(flickAnimationDuration)
       }
@@ -121,7 +121,7 @@ class ImageViewerActivity : AppCompatActivity() {
       }
     }
 
-    val gestureListener = FlickGestureListener(this, contentHeightProvider, gestureCallbacks)
+    val gestureListener = FlickGestureListener(this, contentHeightProvider, callbacks)
     gestureListener.onGestureInterceptor = object : OnGestureInterceptor {
       override fun shouldIntercept(deltaY: Float): Boolean {
         // Don't listen for flick gestures if the image can pan further.

--- a/sample/src/main/java/me/saket/flick/sample/viewer/ImageViewerActivity.kt
+++ b/sample/src/main/java/me/saket/flick/sample/viewer/ImageViewerActivity.kt
@@ -126,7 +126,7 @@ class ImageViewerActivity : AppCompatActivity() {
     val gestureListener = FlickGestureListener(this, contentHeightProvider, callbacks)
 
     // Block flick gestures if the image can pan further.
-    gestureListener.onGestureInterceptor = { scrollY ->
+    gestureListener.gestureInterceptor = { scrollY ->
       val isScrollingUpwards = scrollY < 0
       val directionInt = if (isScrollingUpwards) -1 else +1
       val canPanFurther = imageView.canScrollVertically(directionInt)

--- a/sample/src/main/java/me/saket/flick/sample/viewer/ImageViewerActivity.kt
+++ b/sample/src/main/java/me/saket/flick/sample/viewer/ImageViewerActivity.kt
@@ -14,7 +14,7 @@ import android.view.ViewGroup
 import android.view.WindowManager
 import com.squareup.picasso.Picasso
 import kotterknife.bindView
-import me.saket.flick.ContentHeightProvider
+import me.saket.flick.ContentSizeProvider
 import me.saket.flick.FlickDismissLayout
 import me.saket.flick.FlickGestureListener
 import me.saket.flick.GestureCallbacks
@@ -98,7 +98,7 @@ class ImageViewerActivity : AppCompatActivity() {
   }
 
   private fun flickGestureListener(): FlickGestureListener {
-    val contentHeightProvider = object : ContentHeightProvider {
+    val contentHeightProvider = object : ContentSizeProvider {
       override val heightForDismissAnimation: Int
         get() = imageView.zoomedImageHeight.toInt()
 


### PR DESCRIPTION
I've removed setters for non-optional dependencies in`FlickGestureListener` and moved them to the constructor. The usage instructions on the `README` look a bit neater now:

```kotlin
val contentSizeProvider = object : ContentSizeProvider {
  override val heightForDismissAnimation: Int
    get() = imageView.drawable * imageView.zoomRatio

  override val heightForCalculatingDismissThreshold: Int
    get() {
      // Zoomed in height minus the portions of image that has gone
      // outside display bounds, because they are longer visible.
      imageView.visibleZoomedImageHeight
    }
}

val callbacks = object : FlickCallbacks {
  override fun onFlickDismiss(animationDuration: Long) {
    // Called when the View has been flicked and the Activity
    // should be dismissed.
    flickDismissLayout.postDelayed({ finish() }, animationDuration)
  }

  override fun onMove(@FloatRange(from = -1.0, to = 1.0) moveRatio: Float) {
    // Called while this View is being moved around. Updating
    // background dimming is a good usecase for this callback.
  }
}

val flickDismissLayout: FlickDismissLayout = findViewById(...)
flickDismissLayout.gestureListener = FlickGestureListener(context, contentSizeProvider, callbacks)
```